### PR TITLE
Event description proofreading & fix "SafeOutside"

### DIFF
--- a/BrutalCompanyMinus/Minus/Events/BaboonHorde.cs
+++ b/BrutalCompanyMinus/Minus/Events/BaboonHorde.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "You feel outnumbered", "Keep the doors closed.", "Hear their calls, see their shadows cover the land.", "Why are they also inside??" };
+            Descriptions = new List<string>() { "You feel outnumbered.", "Keep the doors closed.", "Hear their calls. See their shadows cover the land.", "Why are they also inside??" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/BaboonHorde.cs
+++ b/BrutalCompanyMinus/Minus/Events/BaboonHorde.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "You feel outnumbered", "Keep the door's closed.", "Hear their calls, see their shadows cover the land.", "Why are they also inside??" };
+            Descriptions = new List<string>() { "You feel outnumbered", "Keep the doors closed.", "Hear their calls, see their shadows cover the land.", "Why are they also inside??" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/BigBonus.cs
+++ b/BrutalCompanyMinus/Minus/Events/BigBonus.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Corporate is very pleased", "The company has sent you a stimulus check", "Yippeeee" };
+            Descriptions = new List<string>() { "Corporate is very pleased.", "The company has sent you a stimulus check.", "Yippeeee!" };
             ColorHex = "#00FF00";
             Type = EventType.VeryGood;
 

--- a/BrutalCompanyMinus/Minus/Events/Birds.cs
+++ b/BrutalCompanyMinus/Minus/Events/Birds.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "Its bird migration season.", "Birb", "Do these things have feathers?", "You can shoot these." };
+            Descriptions = new List<string>() { "It's bird migration season.", "Birb", "Do these things have feathers?", "You can shoot these." };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
 

--- a/BrutalCompanyMinus/Minus/Events/Birds.cs
+++ b/BrutalCompanyMinus/Minus/Events/Birds.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "Its bird migration season", "Birb", "Do these things have feathers?", "You can shoot these" };
+            Descriptions = new List<string>() { "Its bird migration season.", "Birb", "Do these things have feathers?", "You can shoot these." };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
 

--- a/BrutalCompanyMinus/Minus/Events/BlackFriday.cs
+++ b/BrutalCompanyMinus/Minus/Events/BlackFriday.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Everything is on sale!!!!", "The marketplace is set ablaze with these discounts", "Dont miss out on these deals!" };
+            Descriptions = new List<string>() { "Everything is on sale!!!!", "The marketplace is set ablaze with these discounts.", "Dont miss out on these deals!" };
             ColorHex = "#00FF00";
             Type = EventType.VeryGood;
 

--- a/BrutalCompanyMinus/Minus/Events/Bonus.cs
+++ b/BrutalCompanyMinus/Minus/Events/Bonus.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "Corporate is feeling good today.", "The company is giving you credits for existing.", "$ $ $", "It's never enough." };
+            Descriptions = new List<string>() { "Corporate is feeling good today.", "The company is giving you credits for existing.", "■ ■ ■", "It's never enough." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/Bonus.cs
+++ b/BrutalCompanyMinus/Minus/Events/Bonus.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "Corporate is feeling good today.", "The company is giving you credits for existing", "■ ■ ■", "It's never enough." };
+            Descriptions = new List<string>() { "Corporate is feeling good today.", "The company is giving you credits for existing.", "■ ■ ■", "It's never enough." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/Bonus.cs
+++ b/BrutalCompanyMinus/Minus/Events/Bonus.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "Corporate is feeling good today.", "The company is giving you credits for existing.", "■ ■ ■", "It's never enough." };
+            Descriptions = new List<string>() { "Corporate is feeling good today.", "The company is giving you credits for existing.", "$ $ $", "It's never enough." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/Bounty.cs
+++ b/BrutalCompanyMinus/Minus/Events/Bounty.cs
@@ -22,7 +22,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "The company is now paying for kills", "RIP AND TEAR", "Extermination time", "Monsters roam free, and the price on their heads is mediocre", "The hunt is on!" };
+            Descriptions = new List<string>() { "The company is now paying for kills.", "RIP AND TEAR", "Extermination time", "Monsters roam free, and the price on their heads is mediocre.", "The hunt is on!" };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/Bracken.cs
+++ b/BrutalCompanyMinus/Minus/Events/Bracken.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Your neck tingles", "Your local chiropractors", "I hope you have nyctophobia", "You wont win this staring competition" };
+            Descriptions = new List<string>() { "Your neck tingles...", "Your local chiropractors.", "I hope you have nyctophobia.", "You won't win this staring competition!" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/BugHorde.cs
+++ b/BrutalCompanyMinus/Minus/Events/BugHorde.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Theres too many of them...", "You better be ready for this", "Which ones explode?", "A buzzing doom approaches", "Best with served with yippeeeee mod" };
+            Descriptions = new List<string>() { "There's too many of them!", "You better be ready for this.", "Which ones explode?", "A buzzing doom approaches...", "Best with served with yippeeeee mod." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Butlers.cs
+++ b/BrutalCompanyMinus/Minus/Events/Butlers.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Nicely fashioned gentlemen", "Pop!", "Knives" };
+            Descriptions = new List<string>() { "Nicely fashioned gentlemen.", "Pop!", "Knives!" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/ChineseProduce.cs
+++ b/BrutalCompanyMinus/Minus/Events/ChineseProduce.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Everything here is made cheaply...", "Who produced this crap...", "Budget scrap...", "Quantity over quality" };
+            Descriptions = new List<string>() { "Everything here is made cheaply...", "Who produced this crap...?", "Budget scrap...", "Quantity over quality." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Coilhead.cs
+++ b/BrutalCompanyMinus/Minus/Events/Coilhead.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Coilheads detected in the facility!", "Containment breach!", "Dont turn your back on them...", "Did you know that a severed head usually keeps it's consciousness for about 4 to 5 seconds." };
+            Descriptions = new List<string>() { "Coilheads detected in the facility!", "Containment breach!", "Dont turn your back on them...", "Did you know that a severed head usually keeps its consciousness for about 4 to 5 seconds?" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Dentures.cs
+++ b/BrutalCompanyMinus/Minus/Events/Dentures.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "Grandma forgot her dentures...", "The tooth fairies dream", "It grins from every corner" };
+            Descriptions = new List<string>() { "Grandma forgot her dentures...", "The tooth fairies' dream.", "It grins from every corner." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/Dogs.cs
+++ b/BrutalCompanyMinus/Minus/Events/Dogs.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "They can hear you", "Who's a good boy?", "They aren't good boys ;(", "The ground trembles under their paws", "Bring out your whoopie cushions!", "Make sure to close the door behind you" };
+            Descriptions = new List<string>() { "They can hear you.", "Who's a good boy?", "They aren't good boys. ;(", "The ground trembles under their paws.", "Bring out your whoopie cushions!", "Make sure to close the door behind you!" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/FacilityGhost.cs
+++ b/BrutalCompanyMinus/Minus/Events/FacilityGhost.cs
@@ -21,7 +21,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "There is a ghost in the facility", "Who keeps turning the lights off...", "Paranormal signature detected", "Bring your ouija board" };
+            Descriptions = new List<string>() { "There is a ghost in the facility.", "Who keeps turning the lights off...?", "Paranormal signature detected.", "Bring your ouija board!" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
         }

--- a/BrutalCompanyMinus/Minus/Events/FlowerSnake.cs
+++ b/BrutalCompanyMinus/Minus/Events/FlowerSnake.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "It helps if you weight a little more", "These might take your head off", "Flower snakes!" };
+            Descriptions = new List<string>() { "It helps if you weigh a little more.", "These might take your head off.", "Flower snakes!" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/ForestGiant.cs
+++ b/BrutalCompanyMinus/Minus/Events/ForestGiant.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Eddie hall in the facility?", "Why not", "You hearing stomping inside the facility." };
+            Descriptions = new List<string>() { "Eddie hall in the facility?", "Why not?", "You hearing stomping inside the facility." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/ForestGiant.cs
+++ b/BrutalCompanyMinus/Minus/Events/ForestGiant.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Eddie hall in the facility?", "Why not?", "You hearing stomping inside the facility." };
+            Descriptions = new List<string>() { "Eddie hall in the facility?", "Why not", "You're hearing stomping inside the facility." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/FragileEnemies.cs
+++ b/BrutalCompanyMinus/Minus/Events/FragileEnemies.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Enemies here are a little more fragile than usual.", "Should take 1 less bonk", "A mysterious ailment is making the enemies fragile..." };
+            Descriptions = new List<string>() { "Enemies here are a little more fragile than usual.", "Should take 1 less bonk.", "A mysterious ailment is making the enemies fragile..." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/FullAccess.cs
+++ b/BrutalCompanyMinus/Minus/Events/FullAccess.cs
@@ -25,7 +25,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "Everything is open!", "Someone left the door's open", "Every burgler's dream", "Experience true exploration", "You wont need be needing keys here" };
+            Descriptions = new List<string>() { "Everything is open!", "Someone left the doors open...", "Every burglars' dream", "Experience true exploration!", "You won't need be needing keys here." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/Gloomy.cs
+++ b/BrutalCompanyMinus/Minus/Events/Gloomy.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "It's gloomy out here", "Misty", "Who turned on the fog machine?" };
+            Descriptions = new List<string>() { "It's gloomy out here.", "Misty", "Who turned on the fog machine?" };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
         }

--- a/BrutalCompanyMinus/Minus/Events/GoldenBars.cs
+++ b/BrutalCompanyMinus/Minus/Events/GoldenBars.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Bling Bling!", "It's just like robbing a bank", "I hope this is a sign of good luck", "Are you ready to gain an extra 300+ lbs" };
+            Descriptions = new List<string>() { "Bling bling!", "It's just like robbing a bank!", "I hope this is a sign of good luck.", "Are you ready to gain an extra 300+ lbs?!" };
             ColorHex = "#00FF00";
             Type = EventType.VeryGood;
 

--- a/BrutalCompanyMinus/Minus/Events/GoldenFacility.cs
+++ b/BrutalCompanyMinus/Minus/Events/GoldenFacility.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "The scrap looks shiny", "Valuable scrap ahead", "This facility is rich" };
+            Descriptions = new List<string>() { "The scrap looks shiny.", "Valuable scrap ahead!", "This facility is rich." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/GrabbableLandmines.cs
+++ b/BrutalCompanyMinus/Minus/Events/GrabbableLandmines.cs
@@ -21,7 +21,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Some mines have turned into scrap...", "This was a wonderful idea", "Beep, Beep, Beep.", "You can now sell some of the landmines." };
+            Descriptions = new List<string>() { "Some mines have turned into scrap...", "This was a wonderful idea!", "Beep! Beep! Beep!", "You can now sell some of the landmines." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/GrabbableTurrets.cs
+++ b/BrutalCompanyMinus/Minus/Events/GrabbableTurrets.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Some turrets have turned into scrap...", "You can now offically sell some of the turrets, enjoy!", "You can bring these home for an automated defense system for intruders." };
+            Descriptions = new List<string>() { "Some turrets have turned into scrap...", "You can now offically sell some of the turrets, enjoy!", "You can bring these home for an automated defense system against intruders." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/GrabbableTurrets.cs
+++ b/BrutalCompanyMinus/Minus/Events/GrabbableTurrets.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Some turrets have turned into scrap...", "You can now offically sell some of the turrets, enjoy", "You can bring these home for an automated defense system for intruders." };
+            Descriptions = new List<string>() { "Some turrets have turned into scrap...", "You can now offically sell some of the turrets, enjoy!", "You can bring these home for an automated defense system for intruders." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/HeavyRain.cs
+++ b/BrutalCompanyMinus/Minus/Events/HeavyRain.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "Id rather stay inside", "Even an umbrella wont stop this", "Monsoon!" };
+            Descriptions = new List<string>() { "I'd rather stay inside...", "Even an umbrella wont stop this.", "Monsoon!" };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
 

--- a/BrutalCompanyMinus/Minus/Events/Hell.cs
+++ b/BrutalCompanyMinus/Minus/Events/Hell.cs
@@ -28,7 +28,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Great reward, but at what cost...", "This is the worst event of them all", "You are going to need jesus for this one", "Before crushing the life out of you, I will show you why my power is utterly beyond question!" };
+            Descriptions = new List<string>() { "Great reward, but at what cost...?", "This is the worst event of them all.", "You are going to need Jesus for this one.", "Before crushing the life out of you, I will show you why my power is utterly beyond question!" };
             ColorHex = "#280000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/HoardingBugs.cs
+++ b/BrutalCompanyMinus/Minus/Events/HoardingBugs.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "They look cute.", "Best served bonked", "Pretty innocent" };
+            Descriptions = new List<string>() { "They look cute.", "Best served bonked!", "Pretty innocent" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/HolidaySeason.cs
+++ b/BrutalCompanyMinus/Minus/Events/HolidaySeason.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "It's holiday season", "All the holidays!", "Easter, Halloween and Christmas all in one day." };
+            Descriptions = new List<string>() { "It's the holiday season!", "All the holidays!", "Easter, Halloween, and Christmas all in one day." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/InsideBees.cs
+++ b/BrutalCompanyMinus/Minus/Events/InsideBees.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "BEES!! wait...", "The facility is abuzz!", "Bee careful", "The inside is sweet", "Why was the bee fired from the barbershop? He only knew how to give a buzz cut." };
+            Descriptions = new List<string>() { "BEES!!! ... Wait...", "The facility is abuzz!", "Bee careful", "The inside is sweet!", "Why was the bee fired from the barbershop? He only knew how to give a buzz cut." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Jester.cs
+++ b/BrutalCompanyMinus/Minus/Events/Jester.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "I want to go home.", "Lovely...", "Freeee birdd", "I could go for some hamburgers right about now."};
+            Descriptions = new List<string>() { "I want to go home.", "This isn't funny.", "Freeee birdd", "I could go for some hamburgers right about now."};
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Jester.cs
+++ b/BrutalCompanyMinus/Minus/Events/Jester.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "I want to go home", "Lovely...", "Freeee birdd" };
+            Descriptions = new List<string>() { "I want to go home.", "Lovely...", "Freeee birdd", "I could go for some hamburgers right about now."};
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/KamikazieBugs.cs
+++ b/BrutalCompanyMinus/Minus/Events/KamikazieBugs.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "I rather not anger them if I were you.", "Did you know that hoarding bugs have organs? Well these ones have bombs...", "I hope you meet an army of them.", "An invasion of self-destructing pests insdie the facility." };
+            Descriptions = new List<string>() { "I'd rather not anger them if I were you...", "Did you know that hoarding bugs have organs? Well these ones have bombs!", "I hope you meet an army of them.", "An invasion of self-destructing pests insdie the facility." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/KamikazieBugs.cs
+++ b/BrutalCompanyMinus/Minus/Events/KamikazieBugs.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "I'd rather not anger them if I were you...", "Did you know that hoarding bugs have organs? Well these ones have bombs!", "I hope you meet an army of them.", "An invasion of self-destructing pests insdie the facility." };
+            Descriptions = new List<string>() { "I'd rather not anger them if I were you...", "Did you know that hoarding bugs have organs? Well these ones have bombs!", "I hope you meet an army of them.", "An invasion of self-destructing pests inside the facility." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/Landmines.cs
+++ b/BrutalCompanyMinus/Minus/Events/Landmines.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Watch your step", "This facility is rigged", "Landmines, yes", "+Landmines" };
+            Descriptions = new List<string>() { "Watch your step.", "This facility is rigged.", "Landmines: Yes", "+Landmines" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/LeaflessBrownTrees.cs
+++ b/BrutalCompanyMinus/Minus/Events/LeaflessBrownTrees.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "These trees look spooky", "Brown leafless trees", "Ok" };
+            Descriptions = new List<string>() { "These trees look spooky.", "Brown leafless trees.", "Ok" };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
 

--- a/BrutalCompanyMinus/Minus/Events/LeaflessTrees.cs
+++ b/BrutalCompanyMinus/Minus/Events/LeaflessTrees.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "These trees look dead", "These trees have lost their touch", "It's winter" };
+            Descriptions = new List<string>() { "These trees look dead.", "These trees have lost their touch.", "It's winter!" };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
 

--- a/BrutalCompanyMinus/Minus/Events/LittleGirl.cs
+++ b/BrutalCompanyMinus/Minus/Events/LittleGirl.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "They just want to touch you", "Do you want your head to explode?", "They just want to play with you", "A kingergarten of dead children" };
+            Descriptions = new List<string>() { "They just want to touch you.", "Do you want your head to explode?", "They just want to play with you.", "A kingergarten of dead children!" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Lizard.cs
+++ b/BrutalCompanyMinus/Minus/Events/Lizard.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
 
             Weight = 3;
 
-            Descriptions = new List<string>() { "They dont bite... i swear", "Annoying ones...", "MOVE!!!!!!!!", "These will fart on you, And it isn't pleasent." };
+            Descriptions = new List<string>() { "They dont bite, I swear!", "Annoying ones...", "MOVE!!!!!!!!", "These will fart on you, and it isn't pleasant." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/Locusts.cs
+++ b/BrutalCompanyMinus/Minus/Events/Locusts.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "Locust season is here", "Locusts", "The air fills with the sound of wings." };
+            Descriptions = new List<string>() { "Locust season is here.", "Locusts", "The air fills with the sound of wings." };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
 

--- a/BrutalCompanyMinus/Minus/Events/Masked.cs
+++ b/BrutalCompanyMinus/Minus/Events/Masked.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Friends!!", "Say hi to your new friends", "Lovely bunch of lads", "You might have trust issues after this", "Who's this new guy???" };
+            Descriptions = new List<string>() { "Friends!!!", "Say hi to your new friends!", "Lovely bunch of lads.", "You might have trust issues after this.", "Who's this new guy?!" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/MoreScrap.cs
+++ b/BrutalCompanyMinus/Minus/Events/MoreScrap.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "There is slighly more scrap in the facility!", "This facility was slighly more productive than others.", "Scrap but more." };
+            Descriptions = new List<string>() { "There is slighly more scrap in the facility!", "This facility was slighly more productive than others.", "Scrap, but more." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/NoBracken.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoBracken.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No stalkers", "No chiropractor's", "No more disappearing." };
+            Descriptions = new List<string>() { "No stalkers", "No chiropractors", "No more disappearing." };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoCoilhead.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoCoilhead.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Nothing to stare at today", "No decapitation today, i hope", "No more springs." };
+            Descriptions = new List<string>() { "Nothing to stare at today.", "No decapitation today, I hope", "No more springs." };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoDogs.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoDogs.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No Barking", "You can now party without uninvited guests", "No more doggos" };
+            Descriptions = new List<string>() { "No barking", "You can now party without uninvited guests!", "No more doggos" };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoGhosts.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoGhosts.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No ghosts", "No more paranormal activity", "The ghost busters have cleared this facility of ghosts." };
+            Descriptions = new List<string>() { "No ghosts", "No more paranormal activity.", "The ghost busters have cleared this facility of ghosts." };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoGiants.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoGiants.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No stomping", "Eddie hall isn't allowed here", "No creature's with an IQ of a toddler here, I hope." };
+            Descriptions = new List<string>() { "No stomping", "Eddie hall isn't allowed here.", "No creatures with an IQ of a plant here, I hope." };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoHoardingBugs.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoHoardingBugs.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No critters", "No cuties", "Why are they gone :(" };
+            Descriptions = new List<string>() { "No critters", "No cuties", "Why are they gone? :(", "Not yippee." };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoJester.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoJester.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No more jackbox's", "No cranking", "You dont need to go home today" };
+            Descriptions = new List<string>() { "No more jackboxes", "No cranking", "You dont need to go home today!" };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoLandmines.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoLandmines.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No landmines", "No need to be wary of the floor today.", "Dont expect mines" };
+            Descriptions = new List<string>() { "No landmines", "No need to be wary of the floor today.", "Don't expect mines!" };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoLizards.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoLizards.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No lizards", "No immortal things for whatever reason", "No gas gas gas" };
+            Descriptions = new List<string>() { "No lizards", "No immortal things for whatever reason.", "No gas, gas, gas!" };
             ColorHex = "#008000";
             Type = EventType.Remove;
             EventsToRemove = new List<string>() { nameof(Lizard) };

--- a/BrutalCompanyMinus/Minus/Events/NoMasks.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoMasks.cs
@@ -21,7 +21,7 @@ namespace BrutalCompanyMinus.Minus.Events
             EventsToRemove = new List<string>() { nameof(Hell), nameof(Masked), nameof(NutSlayer) };
 
             Weight = 1;
-            Descriptions = new List<string>() { "No coworkers :(", "No more hugs.", "No more trust issues!" };
+            Descriptions = new List<string>() { "No friends :(", "No more hugs.", "No more trust issues!" };
             ColorHex = "#008000";
             Type = EventType.Remove;
         }

--- a/BrutalCompanyMinus/Minus/Events/NoMasks.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoMasks.cs
@@ -21,7 +21,7 @@ namespace BrutalCompanyMinus.Minus.Events
             EventsToRemove = new List<string>() { nameof(Hell), nameof(Masked), nameof(NutSlayer) };
 
             Weight = 1;
-            Descriptions = new List<string>() { "No friends :(", "No more hugs", "No more trust issues" };
+            Descriptions = new List<string>() { "No coworkers :(", "No more hugs.", "No more trust issues!" };
             ColorHex = "#008000";
             Type = EventType.Remove;
         }

--- a/BrutalCompanyMinus/Minus/Events/NoNutcracker.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoNutcracker.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No nutcrackers", "You are allowed to move", "You wont need to bring your metal codpiece here."};
+            Descriptions = new List<string>() { "No Nutcrackers", "You are allowed to move.", "You won't need to bring your metal codpiece here."};
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoOldBird.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoOldBird.cs
@@ -21,7 +21,7 @@ namespace BrutalCompanyMinus.Minus.Events
             EventsToRemove = new List<string>() { nameof(OldBirds), nameof(Hell) };
 
             Weight = 1;
-            Descriptions = new List<string>() { "No robots", "No deranged children", "No more giant killers" };
+            Descriptions = new List<string>() { "No robots", "No deranged children.", "No more giant killers..." };
             ColorHex = "#008000";
             Type = EventType.Remove;
         }

--- a/BrutalCompanyMinus/Minus/Events/NoSlimes.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoSlimes.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No goo", "No slimes", "A mysterious force repels slimes", "The absence of slimes bring a calm to this planet." };
+            Descriptions = new List<string>() { "No goo", "No slimes", "A mysterious force repels slimes.", "The absence of slimes bring a calm to this planet." };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoThumpers.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoThumpers.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No crawlers", "No drifing", "No more running", "No more sharks", "No legless" };
+            Descriptions = new List<string>() { "No crawlers", "No drifting", "No more running", "No more sharks", "No legless" };
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/NoTurrets.cs
+++ b/BrutalCompanyMinus/Minus/Events/NoTurrets.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "No turrets", "No more home security defense system", "This planet is safe from it's tyranny."};
+            Descriptions = new List<string>() { "No turrets", "No more home security defense system.", "This planet is safe from GLaDOS's tyranny."};
             ColorHex = "#008000";
             Type = EventType.Remove;
 

--- a/BrutalCompanyMinus/Minus/Events/Nothing.cs
+++ b/BrutalCompanyMinus/Minus/Events/Nothing.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "--Nothing--", "Literlly nothing", "Wow it's nothing", "---", "The clouds are happy", "In a suprising twist, nothing happens.", "Consider this a good thing" };
+            Descriptions = new List<string>() { "--Nothing--", "Literally nothing", "Wow... it's nothing...", "---", "The clouds are happy.", "In a suprising twist, nothing happens.", "Consider this a good thing!" };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
         }

--- a/BrutalCompanyMinus/Minus/Events/NutSlayer.cs
+++ b/BrutalCompanyMinus/Minus/Events/NutSlayer.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "The nut slayer is inside the facility...", "Enjoy", "I should make this thing play doom music.", "Even god wont save you from him." };
+            Descriptions = new List<string>() { "The Nutslayer is inside the facility...", "Enjoy", "I should make this thing play DOOM music.", "Even God wont save you from him." };
             ColorHex = "#280000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Nutcracker.cs
+++ b/BrutalCompanyMinus/Minus/Events/Nutcracker.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "This facility is armed.", "You better bring your codpiece", "Try moving, i dare you..." };
+            Descriptions = new List<string>() { "This facility has spreadshot!", "You better bring your codpiece.", "Try moving, I dare you..." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/OldBirds.cs
+++ b/BrutalCompanyMinus/Minus/Events/OldBirds.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Who put that thing in there??", "Mentally deranged toddlers.", "Does the lightning kill them?" };
+            Descriptions = new List<string>() { "Who put that thing in there?!", "Mentally deranged toddlers.", "Does the lightning kill them?" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/OldBirds.cs
+++ b/BrutalCompanyMinus/Minus/Events/OldBirds.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Who put that thing in there??", "Mentally deranged toddlers", "Does the lighnting kill them?" };
+            Descriptions = new List<string>() { "Who put that thing in there??", "Mentally deranged toddlers.", "Does the lightning kill them?" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/OutsideLandmines.cs
+++ b/BrutalCompanyMinus/Minus/Events/OutsideLandmines.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "There are landmines outside.", "This facility had also set up its own booby traps outside.", "Watch your step, outside.", "Iraq" };
+            Descriptions = new List<string>() { "There are landmines, outside.", "This facility had also set up its own booby traps outside.", "Watch your step, outside.", "Iraq" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/OutsideLandmines.cs
+++ b/BrutalCompanyMinus/Minus/Events/OutsideLandmines.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "There are landmines, Outside.", "This facility also has setup it's own booby traps outside", "Watch your step... but outside", "Iraq" };
+            Descriptions = new List<string>() { "There are landmines outside.", "This facility had also set up its own booby traps outside.", "Watch your step, outside.", "Iraq" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/OutsideTurrets.cs
+++ b/BrutalCompanyMinus/Minus/Events/OutsideTurrets.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "The turrets blend in with the trees...", "I hope you enjoy getting shot", "A beautiful day to go outside." };
+            Descriptions = new List<string>() { "The turrets blend in with the trees...", "I hope you enjoy getting shot!", "A beautiful day to go outside." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/Pickles.cs
+++ b/BrutalCompanyMinus/Minus/Events/Pickles.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "Tastes salty...", "Reminds me of grandma", "This cellar is massive" };
+            Descriptions = new List<string>() { "Tastes salty...", "Reminds me of grandma.", "Was this facility a cellar?", "Smells like vinegar." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/PlentyOutsideScrap.cs
+++ b/BrutalCompanyMinus/Minus/Events/PlentyOutsideScrap.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "There is some scrap to be found outside.", "This facility lacks proper waste disposal", "Yay, scrap outside" };
+            Descriptions = new List<string>() { "There is some scrap to be found outside.", "This facility lacks proper waste disposal.", "Yay, scrap outside!" };
             ColorHex = "#00FF00";
             Type = EventType.VeryGood;
 

--- a/BrutalCompanyMinus/Minus/Events/Raining.cs
+++ b/BrutalCompanyMinus/Minus/Events/Raining.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "It's raining out here", "Rain...", "The only thing you will see in Ireland" };
+            Descriptions = new List<string>() { "It's raining out here.", "Rain...", "The only thing you will see in Ireland!" };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
         }

--- a/BrutalCompanyMinus/Minus/Events/RealityShift.cs
+++ b/BrutalCompanyMinus/Minus/Events/RealityShift.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Reality is not what it seems", "The scrap might turn into a landmine", "I hope you are ready to cry", "You might be lucky" };
+            Descriptions = new List<string>() { "Reality is not what it seems.", "The scrap might turn into a landmine!", "I hope you are ready to cry.", "You might be lucky..." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
         }

--- a/BrutalCompanyMinus/Minus/Events/SafeOutside.cs
+++ b/BrutalCompanyMinus/Minus/Events/SafeOutside.cs
@@ -23,7 +23,7 @@ namespace BrutalCompanyMinus.Minus.Events
             EventsToRemove = new List<string>() { nameof(NoOldBird), nameof(NoDogs), nameof(NoGiants), nameof(NoBaboons), nameof(NoWorm), nameof(NoMasks), nameof(NoBirds), nameof(Warzone), nameof(OutsideTurrets), nameof(OutsideLandmines), nameof(Masked), nameof(AllWeather) };
 
             Weight = 1;
-            Descriptions = new List<string>() { "Outside is safe!", "It's unusally quiet outside", "You might find bees outside but that is about it", "You can hear your own footstep's echo as you walk outside." };
+            Descriptions = new List<string>() { "The outdoors is safe!", "It's unusally quiet outside.", "You might find bees outside, but that's about it.", "You can hear your own footsteps echo as you walk outside." };
             ColorHex = "#00FF00";
             Type = EventType.VeryGood;
         }

--- a/BrutalCompanyMinus/Minus/Events/SafeOutside.cs
+++ b/BrutalCompanyMinus/Minus/Events/SafeOutside.cs
@@ -34,14 +34,6 @@ namespace BrutalCompanyMinus.Minus.Events
         {
             Active = true;
             Manager.RemoveSpawn(Assets.EnemyName.Masked);
-            Manager.RemoveSpawn(Assets.EnemyName.OldBird);
-            Manager.RemoveSpawn(Assets.EnemyName.EyelessDog);
-            Manager.RemoveSpawn("SirenHead");
-            Manager.RemoveSpawn(Assets.EnemyName.ForestKeeper);
-            Manager.RemoveSpawn("DriftwoodGiant");
-            Manager.RemoveSpawn("PinkGiant");
-            Manager.RemoveSpawn("DriftwoodGiantObj");
-            Manager.RemoveSpawn("PinkGiantObj");
         }
 
         public override void OnShipLeave() => Active = false;

--- a/BrutalCompanyMinus/Minus/Events/SafeOutside.cs
+++ b/BrutalCompanyMinus/Minus/Events/SafeOutside.cs
@@ -34,6 +34,14 @@ namespace BrutalCompanyMinus.Minus.Events
         {
             Active = true;
             Manager.RemoveSpawn(Assets.EnemyName.Masked);
+            Manager.RemoveSpawn(Assets.EnemyName.OldBird);
+            Manager.RemoveSpawn(Assets.EnemyName.EyelessDog);
+            Manager.RemoveSpawn("SirenHead");
+            Manager.RemoveSpawn(Assets.EnemyName.ForestKeeper);
+            Manager.RemoveSpawn("DriftwoodGiant");
+            Manager.RemoveSpawn("PinkGiant");
+            Manager.RemoveSpawn("DriftwoodGiantObj");
+            Manager.RemoveSpawn("PinkGiantObj");
         }
 
         public override void OnShipLeave() => Active = false;

--- a/BrutalCompanyMinus/Minus/Events/ScarceOutsideScrap.cs
+++ b/BrutalCompanyMinus/Minus/Events/ScarceOutsideScrap.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "There is a scarce amount of scrap outside.", "Someone dumped these out here...", "Grab it before the baboons do" };
+            Descriptions = new List<string>() { "There is a scarce amount of scrap outside.", "Someone dumped these out here.", "Grab it before the baboons do!" };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/ScrapGalore.cs
+++ b/BrutalCompanyMinus/Minus/Events/ScrapGalore.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Scrap here is plentiful and of high quality.", "This planet is blessed with scrap", "You are going to be rich after this haul" };
+            Descriptions = new List<string>() { "Scrap here is plentiful and of high quality.", "This planet is blessed with scrap!", "You are going to be rich after this haul!" };
             ColorHex = "#00FF00";
             Type = EventType.VeryGood;
 

--- a/BrutalCompanyMinus/Minus/Events/ShipmentFees.cs
+++ b/BrutalCompanyMinus/Minus/Events/ShipmentFees.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "The company is now incurring a fee for shipments!", "You are going to be taxed for any shipments...", "I don't recommend buying anything today.", "You might go into debt, beware" };
+            Descriptions = new List<string>() { "The company is now incurring a fee for shipments!", "You are going to be taxed for any shipments...", "I don't recommend buying anything today.", "You might go into debt, beware." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/Slimes.cs
+++ b/BrutalCompanyMinus/Minus/Events/Slimes.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "The ground is sticky", "It's very slow unless you wack it", "Don't get lost in the sauce", "It's mostly water and pain", "blob" };
+            Descriptions = new List<string>() { "The ground is sticky.", "It's very slow, unless you wack it.", "Don't get lost in the sauce.", "It's mostly water and pain.", "blob" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/SmallDelivery.cs
+++ b/BrutalCompanyMinus/Minus/Events/SmallDelivery.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "The company has decided to give you a present.", "Small shipment for small jobs", "Congratz, you have been awarded." };
+            Descriptions = new List<string>() { "The company has decided to give you a present.", "Small shipment for small jobs.", "Congrats, you have been awarded." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/SmallerMap.cs
+++ b/BrutalCompanyMinus/Minus/Events/SmallerMap.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "This facility is smaller.", "Less time running around", "This facility is more compact" };
+            Descriptions = new List<string>() { "This facility is smaller.", "Less time running around.", "This facility is more compact." };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/SnareFleas.cs
+++ b/BrutalCompanyMinus/Minus/Events/SnareFleas.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Ceiling campers!", "A delicacy", "The finest of creatures.", "Look up!", "Don't look down!" };
+            Descriptions = new List<string>() { "Ceiling campers!", "A delicacy", "The finest of creatures.", "Look up!", "Look down" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/SnareFleas.cs
+++ b/BrutalCompanyMinus/Minus/Events/SnareFleas.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Ceiling campers!", "A delicacy", "The finest of creatures", "Look up", "Look down" };
+            Descriptions = new List<string>() { "Ceiling campers!", "A delicacy", "The finest of creatures.", "Look up!", "Don't look down!" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/Spiders.cs
+++ b/BrutalCompanyMinus/Minus/Events/Spiders.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Your skin crawls...", "Not for those with arachnophobia", "Bring your hoover" };
+            Descriptions = new List<string>() { "Your skin crawls...", "Not for those with arachnophobia.", "Bring your hoover." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/SpikeTraps.cs
+++ b/BrutalCompanyMinus/Minus/Events/SpikeTraps.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Spikes!!!", "I recommend looking up", "Hydraulic press!" };
+            Descriptions = new List<string>() { "Spikes!!!", "I recommend looking up.", "Hydraulic press!" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/StrongEnemies.cs
+++ b/BrutalCompanyMinus/Minus/Events/StrongEnemies.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Enemies here are a little more tougher than usual.", "Should take an extra wack or 2", "These monsters are drugged" };
+            Descriptions = new List<string>() { "Enemies here are a little tougher than usual.", "Should take an extra wack or two.", "These monsters are drugged!" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/Thumpers.cs
+++ b/BrutalCompanyMinus/Minus/Events/Thumpers.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "You need to run", "Drifter's", "Sharks!", "Legless" };
+            Descriptions = new List<string>() { "You need to run.", "Drifters!", "Sharks!", "Skipped leg day, but doubled arm day." };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/TransmuteScrapBig.cs
+++ b/BrutalCompanyMinus/Minus/Events/TransmuteScrapBig.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Most scrap has transmuted into something big...", "Everything is heavy...", "Bring your carts!!!", "This is going to be a two-handed job" };
+            Descriptions = new List<string>() { "Most scrap has transmuted into something big!", "Everything is heavy...", "Bring your carts!!!", "This is going to be a two-handed job." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/TransmuteScrapSmall.cs
+++ b/BrutalCompanyMinus/Minus/Events/TransmuteScrapSmall.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 2;
-            Descriptions = new List<string>() { "Most scrap has transmuted into something small...", "This is going to be a one-handed job", "It's all the light stuff" };
+            Descriptions = new List<string>() { "Most scrap has transmuted into something small.", "This is going to be a one-handed job!", "It's all the light stuff!" };
             ColorHex = "#008000";
             Type = EventType.Good;
 

--- a/BrutalCompanyMinus/Minus/Events/Trees.cs
+++ b/BrutalCompanyMinus/Minus/Events/Trees.cs
@@ -20,7 +20,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 8;
-            Descriptions = new List<string>() { "Trees", "More trees", "The trees look like trees" };
+            Descriptions = new List<string>() { "Trees", "More trees.", "The trees look like trees." };
             ColorHex = "#FFFFFF";
             Type = EventType.Neutral;
 

--- a/BrutalCompanyMinus/Minus/Events/Turrets.cs
+++ b/BrutalCompanyMinus/Minus/Events/Turrets.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 3;
-            Descriptions = new List<string>() { "Turrets!!", "Home defense systems", "Panic and scream", "+Turrets" };
+            Descriptions = new List<string>() { "Turrets!!", "Home defense systems.", "Panic and scream!", "+Turrets" };
             ColorHex = "#FF0000";
             Type = EventType.Bad;
 

--- a/BrutalCompanyMinus/Minus/Events/Warzone.cs
+++ b/BrutalCompanyMinus/Minus/Events/Warzone.cs
@@ -25,7 +25,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Landmines? Turrets? all of it", "DDay is here", "Enjoy getting bombarded" };
+            Descriptions = new List<string>() { "Landmines? Turrets? All of it.", "DDay is here...", "Enjoy getting bombarded!" };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 

--- a/BrutalCompanyMinus/Minus/Events/Worms.cs
+++ b/BrutalCompanyMinus/Minus/Events/Worms.cs
@@ -19,7 +19,7 @@ namespace BrutalCompanyMinus.Minus.Events
             Instance = this;
 
             Weight = 1;
-            Descriptions = new List<string>() { "Bug Breach Detected", "The ultimate fine dining experience", "Dont make out with those things" };
+            Descriptions = new List<string>() { "Bug breach detected.", "The ultimate fine dining experience.", "Dont make out with those things!", "Larva the size of a bus." };
             ColorHex = "#800000";
             Type = EventType.VeryBad;
 


### PR DESCRIPTION
A lot of grammatical issues fixed with event descriptions.
Also fixed "SafeOutside" to limit spawns of more than just mimics.